### PR TITLE
Database read optimization

### DIFF
--- a/src/main/java/ml/echelon133/services/graphstorage/config/RedisConfig.java
+++ b/src/main/java/ml/echelon133/services/graphstorage/config/RedisConfig.java
@@ -67,7 +67,20 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, Graph<BigDecimal>> redisTemplate() {
+    public RedisTemplate<String, String> vertexRedisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+
+        redisTemplate.setConnectionFactory(jedisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        LOGGER.info("Instantiating RedisTemplate<String, String> bean");
+
+        return redisTemplate;
+    }
+
+    @Bean
+    public RedisTemplate<String, Graph<BigDecimal>> graphRedisTemplate() {
         RedisTemplate<String, Graph<BigDecimal>> redisTemplate = new RedisTemplate<>();
 
         redisTemplate.setConnectionFactory(jedisConnectionFactory());

--- a/src/main/java/ml/echelon133/services/graphstorage/graph/GraphController.java
+++ b/src/main/java/ml/echelon133/services/graphstorage/graph/GraphController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,6 +33,17 @@ public class GraphController {
 
         LOGGER.debug(String.format("Return response with a serialized graph that has an id %s", id));
         return new ResponseEntity<>(graph, HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}/vertexes")
+    public ResponseEntity<Map<String, Boolean>> checkGraphVertexStatus(@PathVariable String id, @RequestParam String name) throws Exception {
+        LOGGER.debug(String.format("checkGraphVertexStatus of vertex %s in a graph with id %s", name, id));
+
+        Boolean contains = graphRepository.graphHasVertex(id, name);
+
+        Map<String, Boolean> response = Collections.singletonMap("contains", contains);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+
     }
 
     @PostMapping("/")

--- a/src/main/java/ml/echelon133/services/graphstorage/graph/GraphRepository.java
+++ b/src/main/java/ml/echelon133/services/graphstorage/graph/GraphRepository.java
@@ -40,6 +40,12 @@ public class GraphRepository {
     public String save(Graph<BigDecimal> graph) {
         String graphId = UUID.randomUUID().toString();
 
+        // save a set of vertex names needed for vertex membership testing
+        LOGGER.debug(String.format("Method save() tries to save a set of vertex names of a graph %s with id %s", graph, graphId));
+        graph.getVertexes().forEach(
+                vertex -> vertexOpsForSet.add(graphId, vertex.getName())
+        );
+
         LOGGER.debug(String.format("Method save() tries to save graph %s with id %s", graph, graphId));
         graphOpsForHash.put(GRAPH_KEY, graphId, graph);
 

--- a/src/main/java/ml/echelon133/services/graphstorage/graph/GraphRepository.java
+++ b/src/main/java/ml/echelon133/services/graphstorage/graph/GraphRepository.java
@@ -37,6 +37,18 @@ public class GraphRepository {
         LOGGER.info("Instantiated GraphRepository");
     }
 
+    public Boolean graphHasVertex(String graphId, String vertexName) throws GraphNotFoundException {
+        if (!graphOpsForHash.hasKey(GRAPH_KEY, graphId)) {
+            String msg = String.format("Graph with id %s not found", graphId);
+            LOGGER.debug(msg);
+            throw new GraphNotFoundException(msg);
+        }
+
+        Boolean contains = vertexOpsForSet.isMember(graphId, vertexName);
+        LOGGER.debug(String.format("Method graphHasVertex returns %s for graph with id %s and vertexName %s", contains, graphId, vertexName));
+        return contains;
+    }
+
     public String save(Graph<BigDecimal> graph) {
         String graphId = UUID.randomUUID().toString();
 

--- a/src/test/java/ml/echelon133/services/graphstorage/graph/GraphControllerTest.java
+++ b/src/test/java/ml/echelon133/services/graphstorage/graph/GraphControllerTest.java
@@ -417,4 +417,60 @@ public class GraphControllerTest {
         assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         assertThat(response.getContentAsString()).contains(expectedMessage);
     }
+
+    @Test
+    public void checkGraphVertexStatusRespondsCorrectlyWhenGraphNotFound() throws Exception {
+        String searchedId = "asdf";
+        String vertexName = "test";
+
+        String exceptionMsg = String.format("Graph with id %s not found", searchedId);
+
+        // Given
+        given(graphRepository.graphHasVertex(eq(searchedId), eq(vertexName))).willThrow(new GraphNotFoundException(exceptionMsg));
+
+        // When
+        MockHttpServletResponse response = mockMvc.perform(get("/api/graphs/" + searchedId + "/vertexes")
+                .param("name", vertexName)
+                .accept(MediaType.APPLICATION_JSON)).andReturn().getResponse();
+
+        // Then
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+        assertThat(response.getContentAsString()).contains(exceptionMsg);
+    }
+
+    @Test
+    public void checkGraphVertexStatusRespondsCorrectlyWhenGraphHasVertexIsTrue() throws Exception {
+        String searchedId = "asdf";
+        String vertexName = "test";
+
+        // Given
+        given(graphRepository.graphHasVertex(eq(searchedId), eq(vertexName))).willReturn(true);
+
+        // When
+        MockHttpServletResponse response = mockMvc.perform(get("/api/graphs/" + searchedId + "/vertexes")
+                .param("name", vertexName)
+                .accept(MediaType.APPLICATION_JSON)).andReturn().getResponse();
+
+        // Then
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.getContentAsString()).contains("{\"contains\":true}");
+    }
+
+    @Test
+    public void checkGraphVertexStatusRespondsCorrectlyWhenGraphHasVertexIsFalse() throws Exception {
+        String searchedId = "asdf";
+        String vertexName = "test";
+
+        // Given
+        given(graphRepository.graphHasVertex(eq(searchedId), eq(vertexName))).willReturn(false);
+
+        // When
+        MockHttpServletResponse response = mockMvc.perform(get("/api/graphs/" + searchedId + "/vertexes")
+                .param("name", vertexName)
+                .accept(MediaType.APPLICATION_JSON)).andReturn().getResponse();
+
+        // Then
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.getContentAsString()).contains("{\"contains\":false}");
+    }
 }


### PR DESCRIPTION
Implement a way for external web service to quickly check whether a graph with given ID, stored by this service, contains a vertex with a specific name.

This helps to avoid unnecessary database reads, deserialization and serialization of graphs when user requests to execute Dijkstra algorithm starting from an invalid vertex.